### PR TITLE
Update to fill/outline color check

### DIFF
--- a/adafruit_button.py
+++ b/adafruit_button.py
@@ -111,8 +111,8 @@ class Button():
             self.selected_fill = (~self.fill_color) & 0xFFFFFF
         if self.selected_outline is None and outline_color is not None:
             self.selected_outline = (~self.outline_color) & 0xFFFFFF
-
-        if outline_color or fill_color:
+       
+        if (outline_color is not None) or (fill_color is not None):
             if style == Button.RECT:
                 self.body = Rect(x, y, width, height,
                                  fill=self.fill_color, outline=self.outline_color)

--- a/adafruit_button.py
+++ b/adafruit_button.py
@@ -111,7 +111,7 @@ class Button():
             self.selected_fill = (~self.fill_color) & 0xFFFFFF
         if self.selected_outline is None and outline_color is not None:
             self.selected_outline = (~self.outline_color) & 0xFFFFFF
-       
+
         if (outline_color is not None) or (fill_color is not None):
             if style == Button.RECT:
                 self.body = Rect(x, y, width, height,


### PR DESCRIPTION
The current code doesn't draw the button if both fill and outline are 0x000000 (black). With the proposed change, if either the outline or the fill have been assigned any value, the check will pass. If fill and outline are both None, nothing will be drawn.