### PR TITLE
use extended Group instead of property

### DIFF
--- a/adafruit_button.py
+++ b/adafruit_button.py
@@ -100,14 +100,13 @@ class Button(displayio.Group):
         selected_outline=None,
         selected_label=None
     ):
-        super().__init__()
+        super().__init__(x=x, y=y)
         self.x = x
         self.y = y
         self.width = width
         self.height = height
         self._font = label_font
         self._selected = False
-        self.group = displayio.Group()
         self.name = name
         self._label = label
         self.body = self.fill = self.shadow = None
@@ -129,8 +128,8 @@ class Button(displayio.Group):
         if (outline_color is not None) or (fill_color is not None):
             if style == Button.RECT:
                 self.body = Rect(
-                    x,
-                    y,
+                    0,
+                    0,
                     width,
                     height,
                     fill=self.fill_color,
@@ -138,8 +137,8 @@ class Button(displayio.Group):
                 )
             elif style == Button.ROUNDRECT:
                 self.body = RoundRect(
-                    x,
-                    y,
+                    0,
+                    0,
                     width,
                     height,
                     r=10,
@@ -148,11 +147,11 @@ class Button(displayio.Group):
                 )
             elif style == Button.SHADOWRECT:
                 self.shadow = Rect(
-                    x + 2, y + 2, width - 2, height - 2, fill=outline_color
+                    0 + 2, 0 + 2, width - 2, height - 2, fill=outline_color
                 )
                 self.body = Rect(
-                    x,
-                    y,
+                    0,
+                    0,
                     width - 2,
                     height - 2,
                     fill=self.fill_color,
@@ -160,11 +159,11 @@ class Button(displayio.Group):
                 )
             elif style == Button.SHADOWROUNDRECT:
                 self.shadow = RoundRect(
-                    x + 2, y + 2, width - 2, height - 2, r=10, fill=self.outline_color
+                    0 + 2, 0 + 2, width - 2, height - 2, r=10, fill=self.outline_color
                 )
                 self.body = RoundRect(
-                    x,
-                    y,
+                    0,
+                    0,
                     width - 2,
                     height - 2,
                     r=10,
@@ -172,8 +171,8 @@ class Button(displayio.Group):
                     outline=self.outline_color,
                 )
             if self.shadow:
-                self.group.append(self.shadow)
-            self.group.append(self.body)
+                self.append(self.shadow)
+            self.append(self.body)
 
         self.label = label
 
@@ -184,8 +183,8 @@ class Button(displayio.Group):
 
     @label.setter
     def label(self, newtext):
-        if self._label and self.group and (self.group[-1] == self._label):
-            self.group.pop()
+        if self._label and self and (self[-1] == self._label):
+            self.pop()
 
         self._label = None
         if not newtext or (self._label_color is None):  # no new text
@@ -197,10 +196,10 @@ class Button(displayio.Group):
         dims = self._label.bounding_box
         if dims[2] >= self.width or dims[3] >= self.height:
             raise RuntimeError("Button not large enough for label")
-        self._label.x = self.x + (self.width - dims[2]) // 2
-        self._label.y = self.y + self.height // 2
+        self._label.x = 0 + (self.width - dims[2]) // 2
+        self._label.y = 0 + self.height // 2
         self._label.color = self._label_color
-        self.group.append(self._label)
+        self.append(self._label)
 
         if (self.selected_label is None) and (self._label_color is not None):
             self.selected_label = (~self._label_color) & 0xFFFFFF

--- a/adafruit_button.py
+++ b/adafruit_button.py
@@ -146,9 +146,7 @@ class Button(displayio.Group):
                     outline=self.outline_color,
                 )
             elif style == Button.SHADOWRECT:
-                self.shadow = Rect(
-                    2, 2, width - 2, height - 2, fill=outline_color
-                )
+                self.shadow = Rect(2, 2, width - 2, height - 2, fill=outline_color)
                 self.body = Rect(
                     0,
                     0,

--- a/adafruit_button.py
+++ b/adafruit_button.py
@@ -147,7 +147,7 @@ class Button(displayio.Group):
                 )
             elif style == Button.SHADOWRECT:
                 self.shadow = Rect(
-                    0 + 2, 0 + 2, width - 2, height - 2, fill=outline_color
+                    2, 2, width - 2, height - 2, fill=outline_color
                 )
                 self.body = Rect(
                     0,
@@ -159,7 +159,7 @@ class Button(displayio.Group):
                 )
             elif style == Button.SHADOWROUNDRECT:
                 self.shadow = RoundRect(
-                    0 + 2, 0 + 2, width - 2, height - 2, r=10, fill=self.outline_color
+                    2, 2, width - 2, height - 2, r=10, fill=self.outline_color
                 )
                 self.body = RoundRect(
                     0,
@@ -196,8 +196,8 @@ class Button(displayio.Group):
         dims = self._label.bounding_box
         if dims[2] >= self.width or dims[3] >= self.height:
             raise RuntimeError("Button not large enough for label")
-        self._label.x = 0 + (self.width - dims[2]) // 2
-        self._label.y = 0 + self.height // 2
+        self._label.x = (self.width - dims[2]) // 2
+        self._label.y = self.height // 2
         self._label.color = self._label_color
         self.append(self._label)
 

--- a/adafruit_button.py
+++ b/adafruit_button.py
@@ -229,6 +229,16 @@ class Button(displayio.Group):
         if self._label is not None:
             self._label.color = new_label
 
+    @property
+    def group(self):
+        """Return self for compatibility with old API."""
+        print(
+            "Warning: The group property is being deprecated. "
+            "User code should be updated to add the Button directly to the "
+            "Display or other Groups."
+        )
+        return self
+
     def contains(self, point):
         """Used to determine if a point is contained within a button. For example,
         ``button.contains(touch)`` where ``touch`` is the touch point on the screen will allow for

--- a/examples/display_button_customfont.py
+++ b/examples/display_button_customfont.py
@@ -139,7 +139,7 @@ button_6 = Button(
 buttons.append(button_6)
 
 for b in buttons:
-    splash.append(b.group)
+    splash.append(b)
 
 while True:
     p = ts.touch_point

--- a/examples/display_button_simpletest.py
+++ b/examples/display_button_simpletest.py
@@ -45,7 +45,7 @@ button = Button(
 )
 
 # Add button to the display context
-splash.append(button.group)
+splash.append(button)
 
 # Loop and look for touches
 while True:

--- a/examples/display_button_soundboard.py
+++ b/examples/display_button_soundboard.py
@@ -40,7 +40,7 @@ for spot in spots:
         label_color=None,
         name=spot["file"],
     )
-    pyportal.splash.append(button.group)
+    pyportal.splash.append(button)
     buttons.append(button)
 
 last_pressed = None


### PR DESCRIPTION
This is the beginning of a resolution for the issue raised by #22 .

I have done basic testing with a slightly modified simpletest and it seems to be working as intended so far. It does need some more thorough testing though. And the example scripts should be updated to use the the API without accessing `group` property. 

However in making these changes and testing them out I got to thinking about the ramifications a bit more. This change as it is now breaks any existing user code that uses the button since the `group` property will no longer exist. 

Maybe it would be good to provide backwards compatibility for some time by returning the correct thing from a `group` property along with printing a deprecation warning message? 

I will work on getting this tested more and updating the examples this week. I wanted to get this PR created to see if anyone else has thoughts about making this change and/or the deprecation considerations. 