### PR TITLE
adding color properties

### DIFF
--- a/adafruit_button.py
+++ b/adafruit_button.py
@@ -237,7 +237,8 @@ class Button(displayio.Group):
     @fill_color.setter
     def fill_color(self, new_color):
         self._fill_color = _check_color(new_color)
-        self.body.fill = self._fill_color
+        if not self.selected:
+            self.body.fill = self._fill_color
 
     @property
     def outline_color(self):
@@ -247,7 +248,8 @@ class Button(displayio.Group):
     @outline_color.setter
     def outline_color(self, new_color):
         self._outline_color = _check_color(new_color)
-        self.body.outline = self._outline_color
+        if not self.selected:
+            self.body.outline = self._outline_color
 
     @property
     def selected_fill(self):
@@ -257,6 +259,8 @@ class Button(displayio.Group):
     @selected_fill.setter
     def selected_fill(self, new_color):
         self._selected_fill = _check_color(new_color)
+        if self.selected:
+            self.body.fill = self._selected_fill
 
     @property
     def selected_outline(self):
@@ -266,6 +270,8 @@ class Button(displayio.Group):
     @selected_outline.setter
     def selected_outline(self, new_color):
         self._selected_outline = _check_color(new_color)
+        if self.selected:
+            self.body.outline = self._selected_outline
 
     @property
     def selected_label(self):

--- a/adafruit_button.py
+++ b/adafruit_button.py
@@ -94,19 +94,19 @@ class Button(displayio.Group):
         self._label = label
         self.body = self.fill = self.shadow = None
 
-        self.fill_color = _check_color(fill_color)
-        self.outline_color = _check_color(outline_color)
+        self._fill_color = _check_color(fill_color)
+        self._outline_color = _check_color(outline_color)
         self._label_color = label_color
         self._label_font = label_font
         # Selecting inverts the button colors!
-        self.selected_fill = _check_color(selected_fill)
-        self.selected_outline = _check_color(selected_outline)
-        self.selected_label = _check_color(selected_label)
+        self._selected_fill = _check_color(selected_fill)
+        self._selected_outline = _check_color(selected_outline)
+        self._selected_label = _check_color(selected_label)
 
         if self.selected_fill is None and fill_color is not None:
-            self.selected_fill = (~self.fill_color) & 0xFFFFFF
+            self.selected_fill = (~self._fill_color) & 0xFFFFFF
         if self.selected_outline is None and outline_color is not None:
-            self.selected_outline = (~self.outline_color) & 0xFFFFFF
+            self.selected_outline = (~self._outline_color) & 0xFFFFFF
 
         if (outline_color is not None) or (fill_color is not None):
             if style == Button.RECT:
@@ -115,8 +115,8 @@ class Button(displayio.Group):
                     0,
                     width,
                     height,
-                    fill=self.fill_color,
-                    outline=self.outline_color,
+                    fill=self._fill_color,
+                    outline=self._outline_color,
                 )
             elif style == Button.ROUNDRECT:
                 self.body = RoundRect(
@@ -125,8 +125,8 @@ class Button(displayio.Group):
                     width,
                     height,
                     r=10,
-                    fill=self.fill_color,
-                    outline=self.outline_color,
+                    fill=self._fill_color,
+                    outline=self._outline_color,
                 )
             elif style == Button.SHADOWRECT:
                 self.shadow = Rect(2, 2, width - 2, height - 2, fill=outline_color)
@@ -135,12 +135,12 @@ class Button(displayio.Group):
                     0,
                     width - 2,
                     height - 2,
-                    fill=self.fill_color,
-                    outline=self.outline_color,
+                    fill=self._fill_color,
+                    outline=self._outline_color,
                 )
             elif style == Button.SHADOWROUNDRECT:
                 self.shadow = RoundRect(
-                    2, 2, width - 2, height - 2, r=10, fill=self.outline_color
+                    2, 2, width - 2, height - 2, r=10, fill=self._outline_color
                 )
                 self.body = RoundRect(
                     0,
@@ -148,8 +148,8 @@ class Button(displayio.Group):
                     width - 2,
                     height - 2,
                     r=10,
-                    fill=self.fill_color,
-                    outline=self.outline_color,
+                    fill=self._fill_color,
+                    outline=self._outline_color,
                 )
             if self.shadow:
                 self.append(self.shadow)
@@ -200,10 +200,10 @@ class Button(displayio.Group):
             new_out = self.selected_outline
             new_label = self.selected_label
         else:
-            new_fill = self.fill_color
-            new_out = self.outline_color
+            new_fill = self._fill_color
+            new_out = self._outline_color
             new_label = self._label_color
-        # update all relevant colros!
+        # update all relevant colors!
         if self.body is not None:
             self.body.fill = new_fill
             self.body.outline = new_out
@@ -228,3 +228,60 @@ class Button(displayio.Group):
         return (self.x <= point[0] <= self.x + self.width) and (
             self.y <= point[1] <= self.y + self.height
         )
+
+    @property
+    def fill_color(self):
+        """The fill color of the button body"""
+        return self._fill_color
+
+    @fill_color.setter
+    def fill_color(self, new_color):
+        self._fill_color = _check_color(new_color)
+        self.body.fill = self._fill_color
+
+    @property
+    def outline_color(self):
+        """The outline color of the button body"""
+        return self._outline_color
+
+    @outline_color.setter
+    def outline_color(self, new_color):
+        self._outline_color = _check_color(new_color)
+        self.body.outline = self._outline_color
+
+    @property
+    def selected_fill(self):
+        """The fill color of the button body when selected"""
+        return self._selected_fill
+
+    @selected_fill.setter
+    def selected_fill(self, new_color):
+        self._selected_fill = _check_color(new_color)
+
+    @property
+    def selected_outline(self):
+        """The outline color of the button body when selected"""
+        return self._selected_outline
+
+    @selected_outline.setter
+    def selected_outline(self, new_color):
+        self._selected_outline = _check_color(new_color)
+
+    @property
+    def selected_label(self):
+        """The font color of the button when selected"""
+        return self._selected_label
+
+    @selected_label.setter
+    def selected_label(self, new_color):
+        self._selected_label = _check_color(new_color)
+
+    @property
+    def label_color(self):
+        """The font color of the button"""
+        return self._label_color
+
+    @label_color.setter
+    def label_color(self, new_color):
+        self._label_color = _check_color(new_color)
+        self._label.color = self._label_color

--- a/examples/display_button_color_properties.py
+++ b/examples/display_button_color_properties.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2021 foamyguy for Adafruit Industries
+# SPDX-FileCopyrightText: 2021 Tim Cocks for Adafruit Industries
 # SPDX-License-Identifier: MIT
 
 """

--- a/examples/display_button_color_properties.py
+++ b/examples/display_button_color_properties.py
@@ -1,0 +1,80 @@
+# SPDX-FileCopyrightText: 2021 foamyguy for Adafruit Industries
+# SPDX-License-Identifier: MIT
+
+"""
+Basic example that illustrates how to set the various color options on the button using
+properties after the button has been initialized.
+"""
+
+import board
+import displayio
+import terminalio
+import adafruit_touchscreen
+from adafruit_button import Button
+
+# use built in display (PyPortal, PyGamer, PyBadge, CLUE, etc.)
+# see guide for setting up external displays (TFT / OLED breakouts, RGB matrices, etc.)
+# https://learn.adafruit.com/circuitpython-display-support-using-displayio/display-and-display-bus
+display = board.DISPLAY
+
+# --| Button Config |-------------------------------------------------
+BUTTON_X = 110
+BUTTON_Y = 95
+BUTTON_WIDTH = 100
+BUTTON_HEIGHT = 50
+BUTTON_STYLE = Button.ROUNDRECT
+BUTTON_FILL_COLOR = 0xAA0000
+BUTTON_OUTLINE_COLOR = 0x0000FF
+BUTTON_LABEL = "HELLO WORLD"
+BUTTON_LABEL_COLOR = 0x000000
+# --| Button Config |-------------------------------------------------
+
+# Setup touchscreen (PyPortal)
+ts = adafruit_touchscreen.Touchscreen(
+    board.TOUCH_XL,
+    board.TOUCH_XR,
+    board.TOUCH_YD,
+    board.TOUCH_YU,
+    calibration=((5200, 59000), (5800, 57000)),
+    size=(320, 240),
+)
+
+# Make the display context
+splash = displayio.Group()
+display.show(splash)
+
+# Make the button
+button = Button(
+    x=BUTTON_X,
+    y=BUTTON_Y,
+    width=BUTTON_WIDTH,
+    height=BUTTON_HEIGHT,
+    style=BUTTON_STYLE,
+    fill_color=BUTTON_FILL_COLOR,
+    outline_color=BUTTON_OUTLINE_COLOR,
+    label="HELLO WORLD",
+    label_font=terminalio.FONT,
+    label_color=BUTTON_LABEL_COLOR,
+)
+
+button.fill_color = 0x00FF00
+button.outline_color = 0xFF0000
+
+button.selected_fill = (0, 0, 255)
+button.selected_outline = (255, 0, 0)
+
+button.label_color = 0xFF0000
+button.selected_label = 0x00FF00
+
+# Add button to the display context
+splash.append(button)
+
+# Loop and look for touches
+while True:
+    p = ts.touch_point
+    if p:
+        if button.contains(p):
+            print(p)
+            button.selected = True
+    else:
+        button.selected = False


### PR DESCRIPTION
This adds properties to be able to change `fill_color`, `outline_color`, `label_color`, and their "selected" counterparts. 

Previously color changing did not take effect immediately, and many of relevant properties were private.

A new example `examples/display_button_color_properties` has been added to test and illustrate usage of the new properties