### PR TITLE
Update simpletest example for touch "drag-outside" response

### DIFF
--- a/examples/display_button_customfont.py
+++ b/examples/display_button_customfont.py
@@ -1,5 +1,8 @@
 # SPDX-FileCopyrightText: 2021 ladyada for Adafruit Industries
 # SPDX-License-Identifier: MIT
+"""
+Button example with a custom font.
+"""
 
 import os
 import board

--- a/examples/display_button_simpletest.py
+++ b/examples/display_button_simpletest.py
@@ -1,5 +1,8 @@
 # SPDX-FileCopyrightText: 2021 ladyada for Adafruit Industries
 # SPDX-License-Identifier: MIT
+"""
+Simple button example.
+"""
 
 import board
 import displayio
@@ -57,6 +60,6 @@ while True:
         if button.contains(p):
             button.selected = True
         else:
-            button.selected = False # if touch is dragged outside of button
+            button.selected = False  # if touch is dragged outside of button
     else:
-        button.selected = False # if touch is released
+        button.selected = False  # if touch is released

--- a/examples/display_button_simpletest.py
+++ b/examples/display_button_simpletest.py
@@ -42,7 +42,7 @@ button = Button(
     style=BUTTON_STYLE,
     fill_color=BUTTON_FILL_COLOR,
     outline_color=BUTTON_OUTLINE_COLOR,
-    label="HELLO WORLD",
+    label=BUTTON_LABEL,
     label_font=terminalio.FONT,
     label_color=BUTTON_LABEL_COLOR,
 )
@@ -56,5 +56,7 @@ while True:
     if p:
         if button.contains(p):
             button.selected = True
+        else:
+            button.selected = False # if touch is dragged outside of button
     else:
-        button.selected = False
+        button.selected = False # if touch is released

--- a/examples/display_button_soundboard.py
+++ b/examples/display_button_soundboard.py
@@ -1,5 +1,8 @@
 # SPDX-FileCopyrightText: 2021 ladyada for Adafruit Industries
 # SPDX-License-Identifier: MIT
+"""
+Soundboard example with buttons.
+"""
 
 import time
 from adafruit_pyportal import PyPortal


### PR DESCRIPTION
This is more of a stylistic change to highlight the button response, if you don't think it adds anything, I'm fine cancelling this PR.

Existing code:
When the button is pressed and the touch is dragged outside of the button, the button remains pressed.  Only removing the touch from the screen will reset the button.

New code:
The button is cleared if the touch is dragged outside the button.  

Minor edits:
Also, I had to clean up some doc-string pylint errors in the examples, and I made one update to use the pre-defined `BUTTON_LABEL` variable.