### PR TITLE
Allow label to be scaled

### DIFF
--- a/adafruit_button/button.py
+++ b/adafruit_button/button.py
@@ -130,7 +130,8 @@ class Button(ButtonBase):
         label_color=0x0,
         selected_fill=None,
         selected_outline=None,
-        selected_label=None
+        selected_label=None,
+        label_scale=None
     ):
         super().__init__(
             x=x,
@@ -142,6 +143,7 @@ class Button(ButtonBase):
             label_font=label_font,
             label_color=label_color,
             selected_label=selected_label,
+            label_scale=label_scale,
         )
 
         self.body = self.fill = self.shadow = None

--- a/adafruit_button/button_base.py
+++ b/adafruit_button/button_base.py
@@ -58,7 +58,8 @@ class ButtonBase(Group):
         label=None,
         label_font=None,
         label_color=0x0,
-        selected_label=None
+        selected_label=None,
+        label_scale=None
     ):
         super().__init__(x=x, y=y)
         self.x = x
@@ -72,6 +73,7 @@ class ButtonBase(Group):
         self._label_color = label_color
         self._label_font = label_font
         self._selected_label = _check_color(selected_label)
+        self._label_scale = label_scale or 1
 
     @property
     def label(self):
@@ -89,14 +91,18 @@ class ButtonBase(Group):
 
         if not self._label_font:
             raise RuntimeError("Please provide label font")
-        self._label = Label(self._label_font, text=newtext)
-        dims = self._label.bounding_box
+        self._label = Label(self._label_font, text=newtext, scale=self._label_scale)
+        dims = list(self._label.bounding_box)
+        dims[2] *= self._label.scale
+        dims[3] *= self._label.scale
         if dims[2] >= self.width or dims[3] >= self.height:
             while len(self._label.text) > 1 and (
                 dims[2] >= self.width or dims[3] >= self.height
             ):
                 self._label.text = "{}.".format(self._label.text[:-2])
                 dims = self._label.bounding_box
+                dims[2] *= self._label.scale
+                dims[3] *= self._label.scale
             if len(self._label.text) <= 1:
                 raise RuntimeError("Button not large enough for label")
         self._label.x = (self.width - dims[2]) // 2

--- a/adafruit_button/button_base.py
+++ b/adafruit_button/button_base.py
@@ -100,7 +100,7 @@ class ButtonBase(Group):
                 dims[2] >= self.width or dims[3] >= self.height
             ):
                 self._label.text = "{}.".format(self._label.text[:-2])
-                dims = self._label.bounding_box
+                dims = list(self._label.bounding_box)
                 dims[2] *= self._label.scale
                 dims[3] *= self._label.scale
             if len(self._label.text) <= 1:

--- a/adafruit_button/sprite_button.py
+++ b/adafruit_button/sprite_button.py
@@ -56,7 +56,8 @@ class SpriteButton(ButtonBase):
         selected_label=None,
         bmp_path=None,
         selected_bmp_path=None,
-        transparent_index=None
+        transparent_index=None,
+        label_scale=None
     ):
         if bmp_path is None:
             raise ValueError("Please supply bmp_path. It cannot be None.")
@@ -71,6 +72,7 @@ class SpriteButton(ButtonBase):
             label_font=label_font,
             label_color=label_color,
             selected_label=selected_label,
+            label_scale=label_scale
         )
 
         self._bmp, self._bmp_palette = load(bmp_path)

--- a/adafruit_button/sprite_button.py
+++ b/adafruit_button/sprite_button.py
@@ -72,7 +72,7 @@ class SpriteButton(ButtonBase):
             label_font=label_font,
             label_color=label_color,
             selected_label=selected_label,
-            label_scale=label_scale
+            label_scale=label_scale,
         )
 
         self._bmp, self._bmp_palette = load(bmp_path)


### PR DESCRIPTION
### Problem
When creating a `Button`, there isn't a way to set the scale for the label font, so the label for bigger buttons can be tiny. See #41.

### Changes

- `__init__` for `Button` and `ButtonBase` now take an optional `label_scale` parameter, which ultimately defaults to 1
- In the setter for `label`, when the `Label` is instantiated, it is passed the label scale. Then, to ensure the label is centered, the bounding box is modified by the scale factor as necessary. 

### Testing
I don't have a ton of experience with this library or its dependencies, so I admittedly didn't do much testing. My application uses some buttons with the font scaled to 2 and 4 and everything seems to work okay. I'm open to doing more testing if there are suggestions.

### Notes

- I'm not sure if it's a bug or intentional that the `Label`'s bounding box isn't scaled, and I considered submitting a pull request in that repository to add a `scaled_bounding_box` property, but I figured the way the dependencies are for these libraries, it would be best for this change to be compatible with the current and previous Adafruit_CircuitPython_Display_Text versions.
- As I'm writing this realizing that it is possible to create a small button then scale the whole button up and the text scales with it. That might be an okay work-around but I'm not sure it's intuitive so I still think this change is worthwhile.