### PR TITLE
Fix null error from label property / resize

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,7 +18,7 @@ repos:
       - id: end-of-file-fixer
       - id: trailing-whitespace
   - repo: https://github.com/pycqa/pylint
-    rev: v2.17.4
+    rev: v3.3.1
     hooks:
       - id: pylint
         name: pylint (library code)

--- a/.pylintrc
+++ b/.pylintrc
@@ -361,7 +361,7 @@ valid-metaclass-classmethod-first-arg=mcs
 [DESIGN]
 
 # Maximum number of arguments for function / method
-max-args=5
+max-args=18
 
 # Maximum number of attributes for a class (see R0902).
 # max-attributes=7

--- a/adafruit_button/button_base.py
+++ b/adafruit_button/button_base.py
@@ -78,9 +78,7 @@ class ButtonBase(Group):
     @property
     def label(self):
         """The text label of the button"""
-        if self._label is not None and hasattr(self._label, "text"):
-            return self._label.text
-        return None
+        return getattr(self._label, "text", None)
 
     @label.setter
     def label(self, newtext):

--- a/adafruit_button/button_base.py
+++ b/adafruit_button/button_base.py
@@ -78,7 +78,9 @@ class ButtonBase(Group):
     @property
     def label(self):
         """The text label of the button"""
-        return self._label.text
+        if self._label is not None and hasattr(self._label, "text"):
+            return self._label.text
+        return None
 
     @label.setter
     def label(self, newtext):


### PR DESCRIPTION
Resolves #45 

Check for null and ensure text property before trying to access it. `self._label` holds a string for a short window of time after the super init is called before changing to hold a Label object. The property accessor assumed that it would always be a Label object.

Also updated pylint to newest.