### PR TITLE
Exposed Name attribute

### DIFF
--- a/adafruit_button/button_base.py
+++ b/adafruit_button/button_base.py
@@ -68,7 +68,7 @@ class ButtonBase(Group):
         self._height = height
         self._font = label_font
         self._selected = False
-        self.name = name
+        self._name = name
         self._label = label
         self._label_color = label_color
         self._label_font = label_font
@@ -157,3 +157,12 @@ class ButtonBase(Group):
     def label_color(self, new_color):
         self._label_color = _check_color(new_color)
         self._label.color = self._label_color
+
+    @property
+    def name(self) -> str:
+        """The name of the button"""
+        return self._name
+
+    @name.setter
+    def name(self, new_name: str) -> None:
+        self._name = new_name


### PR DESCRIPTION
Exposed the name property so that it can be set and retrieved. This is a useful idea that hadnt been fully implemented.