### PR TITLE
move contains() to base and add support for FocalTouch

### DIFF
--- a/adafruit_button/button.py
+++ b/adafruit_button/button.py
@@ -211,15 +211,6 @@ class Button(ButtonBase):
         )
         return self
 
-    def contains(self, point: tuple[int, int]) -> bool:
-        """Used to determine if a point is contained within a button. For example,
-        ``button.contains(touch)`` where ``touch`` is the touch point on the screen will allow for
-        determining that a button has been touched.
-        """
-        return (self.x <= point[0] <= self.x + self.width) and (
-            self.y <= point[1] <= self.y + self.height
-        )
-
     @property
     def fill_color(self) -> Optional[int]:
         """The fill color of the button body"""

--- a/adafruit_button/button_base.py
+++ b/adafruit_button/button_base.py
@@ -178,7 +178,7 @@ class ButtonBase(Group):
     def name(self, new_name: str) -> None:
         self._name = new_name
 
-    def contains(self, point: Union[tuple[int, int], List[int, int], List[Dict[str, int]]]) -> bool:
+    def contains(self, point: Union[tuple[int, int], List[int], List[Dict[str, int]]]) -> bool:
         """Used to determine if a point is contained within a button. For example,
         ``button.contains(touch)`` where ``touch`` is the touch point on the screen will allow for
         determining that a button has been touched.

--- a/adafruit_button/button_base.py
+++ b/adafruit_button/button_base.py
@@ -27,7 +27,7 @@ from adafruit_display_text.bitmap_label import Label
 from displayio import Group
 
 try:
-    from typing import Optional, Tuple, Union
+    from typing import Dict, List, Optional, Tuple, Union
 
     from fontio import FontProtocol
 except ImportError:
@@ -177,3 +177,27 @@ class ButtonBase(Group):
     @name.setter
     def name(self, new_name: str) -> None:
         self._name = new_name
+
+    def contains(self, point: Union[tuple[int, int], List[int, int], List[Dict[str, int]]]) -> bool:
+        """Used to determine if a point is contained within a button. For example,
+        ``button.contains(touch)`` where ``touch`` is the touch point on the screen will allow for
+        determining that a button has been touched.
+        """
+        if isinstance(point, tuple) or (isinstance(point, list) and isinstance(point[0], int)):
+            return (self.x <= point[0] <= self.x + self.width) and (
+                self.y <= point[1] <= self.y + self.height
+            )
+        elif isinstance(point, list):
+            touch_points = point
+            if len(touch_points) == 0:
+                return False
+            for touch_point in touch_points:
+                if (
+                    isinstance(touch_point, dict)
+                    and "x" in touch_point.keys()
+                    and "y" in touch_point.keys()
+                ):
+                    if self.contains((touch_point["x"], touch_point["y"])):
+                        return True
+
+        return False

--- a/adafruit_button/sprite_button.py
+++ b/adafruit_button/sprite_button.py
@@ -130,15 +130,6 @@ class SpriteButton(ButtonBase):
         """The height of the button. Read-Only"""
         return self._height
 
-    def contains(self, point: Tuple[int, int]) -> bool:
-        """Used to determine if a point is contained within a button. For example,
-        ``button.contains(touch)`` where ``touch`` is the touch point on the screen will allow for
-        determining that a button has been touched.
-        """
-        return (self.x <= point[0] <= self.x + self.width) and (
-            self.y <= point[1] <= self.y + self.height
-        )
-
     def _subclass_selected_behavior(self, value: bool) -> None:
         if self._selected:
             if self._selected_bmp is not None:


### PR DESCRIPTION
@ladyada 
Resolves: #47 

Both buttons `contains()` implementation was the same so I moved it to the base class instead of the children. Added logic to account for list of dictionaries with x,y keys returned by `focaltouch.touches`